### PR TITLE
emergency patch set .default for title display none

### DIFF
--- a/css/edoweb_lbz.css
+++ b/css/edoweb_lbz.css
@@ -340,7 +340,7 @@ table h1.title, h2.title-suffix {
 }
 
 /* css based reduced information set: get rid of unessessary fields */
-.field-name-field-edoweb-title {
+.default .field-name-field-edoweb-title {
   display: none;
 }
 


### PR DESCRIPTION
As change of title does not work if there is no title-field displayed in the form patch is needed for using style display:none only for not logged in users