### PR TITLE
Hide unwanted forms

### DIFF
--- a/css/edoweb_lbz.css
+++ b/css/edoweb_lbz.css
@@ -434,6 +434,10 @@ display: none;
     display: none;
 }
 
+.form-type-item a[data-bundle=version]{
+    display: none;
+}
+
 #edoweb-tree-menu a[data-bundle=researchData]{
     display: none;
 }

--- a/css/edoweb_lbz.css
+++ b/css/edoweb_lbz.css
@@ -454,6 +454,10 @@ display: none;
     display: none;
 }
 
+#edoweb-tree-menu a[data-bundle=version]{
+    display: none;
+}
+
 #edoweb-basic-crawler-form .form-item{
 display:block;
 clear:both;


### PR DESCRIPTION
This pull request is for hiding all links to forms for object types not supported by edoweb, e.g. research data., issue,...  It simply uses css to hide the existing links at content area and tree-menu area