### PR TITLE
Cumulative fixes

### DIFF
--- a/css/edoweb_lbz.css
+++ b/css/edoweb_lbz.css
@@ -434,6 +434,10 @@ display: none;
     display: none;
 }
 
+.form-type-item a[data-bundle=version]{
+    display: none;
+}
+
 #edoweb-tree-menu a[data-bundle=researchData]{
     display: none;
 }

--- a/css/edoweb_lbz.css
+++ b/css/edoweb_lbz.css
@@ -413,7 +413,49 @@ display: none;
         display: none;
 }
 
+/* hide all forms for object types not supported by edoweb */ 
+.form-type-item a[data-bundle=researchData]{
+    display: none;
+}
+
+.form-type-item a[data-bundle=volume]{
+    display: none;
+}
+
+.form-type-item a[data-bundle=proceeding]{
+    display: none;
+}
+
+.form-type-item a[data-bundle=issue]{
+    display: none;
+}
+
+.form-type-item a[data-bundle=article]{
+    display: none;
+}
+
+#edoweb-tree-menu a[data-bundle=researchData]{
+    display: none;
+}
+
+#edoweb-tree-menu a[data-bundle=volume]{
+    display: none;
+}
+
+#edoweb-tree-menu a[data-bundle=proceeding]{
+    display: none;
+}
+
+#edoweb-tree-menu a[data-bundle=issue]{
+    display: none;
+}
+
+#edoweb-tree-menu a[data-bundle=article]{
+    display: none;
+}
+
 #edoweb-basic-crawler-form .form-item{
 display:block;
 clear:both;
 }
+

--- a/css/edoweb_lbz.css
+++ b/css/edoweb_lbz.css
@@ -467,3 +467,9 @@ display:block;
 clear:both;
 }
 
+/* workaround for displaying notations, associated with notationWA.js */
+.field-name-field-edoweb-rpb-subject .lbznotation {
+margin-right:20px;
+float:left;
+min-width: 70px;
+}

--- a/css/edoweb_lbz.css
+++ b/css/edoweb_lbz.css
@@ -454,6 +454,10 @@ display: none;
     display: none;
 }
 
+#edoweb-tree-menu a[data-bundle=version]{
+    display: none;
+}
+
 #edoweb-basic-crawler-form .form-item{
 display:block;
 clear:both;

--- a/css/edoweb_lbz.css
+++ b/css/edoweb_lbz.css
@@ -385,10 +385,17 @@ div.field.field-name-field-edoweb-struct-child.field-type-edoweb-ld-reference.fi
 {
  
 }
-.field-name-field-mab-710{
-display: none;
 
+.field-name-field-mab-710 .field-item{
+float:left;
+margin-left: 0em !important;
+margin-right: 0.2em;
 }
+
+.field-name-field-mab-710 .field-items{
+margin-left: 12em;
+}
+
 .field-name-field-edoweb-institution{
 display: none;
 }

--- a/edoweb_lbz.info
+++ b/edoweb_lbz.info
@@ -11,6 +11,7 @@ stylesheets[all][] = octicons/octicons.css
 stylesheets[all][] = batch-icons/batch-icons.css
 scripts[] = facets.js
 scripts[] = theme.js
+scripts[] = js/isbnformat.js
 scripts[] = jquery.cookie.js
 
 regions[header] = Header

--- a/edoweb_lbz.info
+++ b/edoweb_lbz.info
@@ -13,6 +13,7 @@ scripts[] = facets.js
 scripts[] = theme.js
 scripts[] = js/isbnformat.js
 scripts[] = jquery.cookie.js
+scripts[] = js/notationWA.js
 
 regions[header] = Header
 regions[help] = Help

--- a/edoweb_lbz.info
+++ b/edoweb_lbz.info
@@ -14,6 +14,7 @@ scripts[] = theme.js
 scripts[] = js/isbnformat.js
 scripts[] = jquery.cookie.js
 scripts[] = js/notationWA.js
+scripts[] = js/mab710WA.js
 
 regions[header] = Header
 regions[help] = Help

--- a/js/isbnformat.js
+++ b/js/isbnformat.js
@@ -6,7 +6,7 @@
     attach: function (context, settings) {
 
       var serviceurl = "https://nyx.hbz-nrw.de/";
-      var service = "?value=";
+      var service = "isbn?value=";
       // Use callback if Service is JSONP
       //var callback = "&callback=?";
       var callback = "";

--- a/js/isbnformat.js
+++ b/js/isbnformat.js
@@ -5,8 +5,8 @@
   Drupal.behaviors.edoweb_drupal_isbn10_format = {
     attach: function (context, settings) {
 
-      var serviceurl = "https://index.hbz-nrw.de/";
-      var service = "_es2/_isbn?value=";
+      var serviceurl = "https://nyx.hbz-nrw.de/";
+      var service = "?value=";
       // Use callback if Service is JSONP
       //var callback = "&callback=?";
       var callback = "";

--- a/js/isbnformat.js
+++ b/js/isbnformat.js
@@ -11,7 +11,7 @@
       //var callback = "&callback=?";
       var callback = "";
 
-      $('.field-name-field-edoweb-isbn10 .field-item').once(function(){
+      $('.field-name-field-edoweb-isbn10 .field-item', context).once(function(){
         
         var isbn = $(this).html();
         getIsbnFormatted();

--- a/js/isbnformat.js
+++ b/js/isbnformat.js
@@ -1,0 +1,37 @@
+(function($) {
+
+
+
+  Drupal.behaviors.edoweb_drupal_isbn10_format = {
+    attach: function (context, settings) {
+
+      var serviceurl = "https://index.hbz-nrw.de/";
+      var service = "_es2/_isbn?value=";
+      // Use callback if Service is JSONP
+      //var callback = "&callback=?";
+      var callback = "";
+
+      $('.field-name-field-edoweb-isbn10 .field-item').once(function(){
+        
+        var isbn = $(this).html();
+        getIsbnFormatted();
+  
+  
+        function getIsbnFormatted (){
+          var url = serviceurl + service + isbn + callback;
+    
+          $.getJSON(url, function(json) {
+             $('.field-name-field-edoweb-isbn10 .field-item').html(json.result.isbn10formatted);
+            
+             $('.field-name-field-edoweb-isbn10')
+                .after('<div class="field-name-field-edoweb-isbn13"></div>')
+                .append('<div class="field-label">ISBN-13:</div><div class="field-item">' + json.result.isbn13formatted + '</div>');
+       
+             });
+          };
+  
+      });
+    }
+  };
+
+})(jQuery);

--- a/js/mab710WA.js
+++ b/js/mab710WA.js
@@ -1,0 +1,15 @@
+(function($){
+
+    Drupal.behaviors.edoweb_drupal_theme_entity_minimize = {
+    attach: function (context, settings) {
+
+      $('.field-name-field-edoweb-subject-chain', context).once(function() {
+        //$(this).after('<div class="field field-name-edoweb-field-toggle"><div class="field-label">Alle Schlagwörter anzeigen <span class="octicon octicon-triangle-right"</span></div></div>');
+        $('.field-name-field-mab-710').hide();
+        
+      });
+
+    } 
+  };
+
+})(jQuery);

--- a/js/notationWA.js
+++ b/js/notationWA.js
@@ -1,0 +1,19 @@
+(function($) {
+
+
+
+  Drupal.behaviors.edoweb_drupal_notationWA = {
+    attach: function (context, settings) {
+
+      $('.field-name-field-edoweb-rpb-subject .field-item').each(function() {
+        var notationAttr = $(this).find('a.resolved').attr('data-curie').replace(/https:\/\/w3id.org\/lobid\/rpb2#n/,'')
+        .replace(/:n/, '');
+        $(this).prepend('<div class="lbznotation">' + notationAttr + '</div>');
+    
+      });
+    }
+  };
+
+})(jQuery);
+
+


### PR DESCRIPTION
This branch provides all fixes created to solve three open issues:

1. adding hyphens to isbn at items-display.: also fixes issue that field isbn10 often shows isbn13
2. displaying mab710 at items-page: not entirely solved, patch of lobid data needed
3. hiding links to forms not needed by LBZ: e.g. Volume, Issue, Version 