### PR TITLE
Paste wa

### DIFF
--- a/edoweb_lbz.info
+++ b/edoweb_lbz.info
@@ -15,7 +15,7 @@ scripts[] = js/isbnformat.js
 scripts[] = jquery.cookie.js
 scripts[] = js/notationWA.js
 scripts[] = js/mab710WA.js
-
+scripts[] = js/pasteWA.js
 regions[header] = Header
 regions[help] = Help
 regions[page_top] = Page top

--- a/js/pasteWA.js
+++ b/js/pasteWA.js
@@ -3,7 +3,7 @@
     Drupal.behaviors.edoweb_drupal_theme_paste = {
       attach: function (context, settings) {
 
-        $('.field-item[contenteditable="true"]').once(function() {
+        $('.field-item[contenteditable="true"]', context).once(function() {
           $(this).bind('paste', function(e){
 
             // prevent execution of paste
@@ -12,6 +12,7 @@
             // get clipboard data as plain text
             var text = e.originalEvent.clipboardData.getData("text/plain");
 
+            // concat clipboard plain text with existing content of contenteditable element 
             var concattext = $(this).html().substr(0, window.getSelection().anchorOffset) + text + $(this).html().substr(window.getSelection().anchorOffset);
       
             $(this).empty().append( concattext );

--- a/js/pasteWA.js
+++ b/js/pasteWA.js
@@ -3,8 +3,8 @@
     Drupal.behaviors.edoweb_drupal_theme_paste = {
       attach: function (context, settings) {
 
-        $('.field-item').attr('contenteditable','true').each(function() {
-          $(this).on('paste', function(e){
+        $('.field-item[contenteditable="true"]').once(function() {
+          $(this).bind('paste', function(e){
 
             // prevent execution of paste
             e.preventDefault();

--- a/js/pasteWA.js
+++ b/js/pasteWA.js
@@ -1,5 +1,4 @@
 (function($){
-
     Drupal.behaviors.edoweb_drupal_theme_paste = {
       attach: function (context, settings) {
 
@@ -8,15 +7,29 @@
 
             // prevent execution of paste
             e.preventDefault();
-      
+
             // get clipboard data as plain text
-            var text = e.originalEvent.clipboardData.getData("text/plain");
+            var text = '';
+
+            // code for debugging purposes
+            /*
+             $.each($.browser, function(i, val){
+              $('body').append("<h1>" + i + " : <span>" + val + "</span></h1>");
+            });
+            */
+
+            // integrate check for ie11 as ie 11 does't support default method
+            if (($.browser.msie || $.browser.mozilla) && $.browser.version >= 11 && $.browser.version <= 12){
+               text = window.clipboardData.getData("text");
+            }else {
+               text = e.originalEvent.clipboardData.getData("text/plain");
+            }
 
             // concat clipboard plain text with existing content of contenteditable element 
             var concattext = $(this).html().substr(0, window.getSelection().anchorOffset) + text + $(this).html().substr(window.getSelection().anchorOffset);
-      
+
             $(this).empty().append( concattext );
-      
+
           });
         });
       }

--- a/js/pasteWA.js
+++ b/js/pasteWA.js
@@ -1,23 +1,24 @@
 (function($){
 
     Drupal.behaviors.edoweb_drupal_theme_paste = {
-    attach: function (context, settings) {
+      attach: function (context, settings) {
 
-      $$('.field-item').attr('contenteditable','true').each(function() {
-        $(this).on('paste', function(e){
+        $('.field-item').attr('contenteditable','true').each(function() {
+          $(this).on('paste', function(e){
 
-         // prevent execution of paste
-         e.preventDefault();
+            // prevent execution of paste
+            e.preventDefault();
       
-         // get clipboard data as plain text
-         var text = e.originalEvent.clipboardData.getData("text/plain");
+            // get clipboard data as plain text
+            var text = e.originalEvent.clipboardData.getData("text/plain");
 
-         var concattext = $(this).html().substr(0, window.getSelection().anchorOffset) + text + $(this).html().substr(window.getSelection().anchorOffset);
+            var concattext = $(this).html().substr(0, window.getSelection().anchorOffset) + text + $(this).html().substr(window.getSelection().anchorOffset);
       
-         $(this).empty().append( concattext );
+            $(this).empty().append( concattext );
       
-      });
-    });
-  }
+          });
+        });
+      }
+    }
 
 })(jQuery);

--- a/js/pasteWA.js
+++ b/js/pasteWA.js
@@ -1,0 +1,23 @@
+(function($){
+
+    Drupal.behaviors.edoweb_drupal_theme_paste = {
+    attach: function (context, settings) {
+
+      $$('.field-item').attr('contenteditable','true').each(function() {
+        $(this).on('paste', function(e){
+
+         // prevent execution of paste
+         e.preventDefault();
+      
+         // get clipboard data as plain text
+         var text = e.originalEvent.clipboardData.getData("text/plain");
+
+         var concattext = $(this).html().substr(0, window.getSelection().anchorOffset) + text + $(this).html().substr(window.getSelection().anchorOffset);
+      
+         $(this).empty().append( concattext );
+      
+      });
+    });
+  }
+
+})(jQuery);


### PR DESCRIPTION
this a fix to get plain text into a contenteditable field via paste instead of getting all clipboard content dumped into the field. As the IE11 does NOT support default behavior we have had to put a browser recognition to the code