### PR TITLE
providing patch for order of divs within the isbn-fields

### DIFF
--- a/js/isbnformat.js
+++ b/js/isbnformat.js
@@ -22,11 +22,12 @@
     
           $.getJSON(url, function(json) {
              $('.field-name-field-edoweb-isbn10 .field-item').html(json.result.isbn10formatted);
-            
+
              $('.field-name-field-edoweb-isbn10')
-                .after('<div class="field-name-field-edoweb-isbn13"></div>')
-                .append('<div class="field-label">ISBN-13:</div><div class="field-item">' + json.result.isbn13formatted + '</div>');
-       
+                .after('<div class="field field-name-field-edoweb-isbn13"></div>');
+
+             //$('.field-name-field-edoweb-isbn10').hide();
+             $('.field-name-field-edoweb-isbn13').append('<div class="field-label">ISBN-13:</div><div class="field-items"><div class="field-item">' + json.result.isbn13formatted + '</div></div>');
              });
           };
   


### PR DESCRIPTION
former version was creating the '<div class="field-name-field-edoweb-isbn13"></div>' inside of  '<div class="field-name-field-edoweb-isbn10"></div>' instead of after.  

This patch will fix this